### PR TITLE
Add possibility of installing CPU version only

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,12 +79,19 @@ if state_space_restriction.cuda_available() == state_space_restriction.CUDA_NOT_
 
 Be especially aware of the ```CUDA_NOT_FUNCTIONAL``` case: This means that the CUDA compiler
 is installed on your device but basic functionalities like allocating memory on the GPU
-are not working as expected. In this case
-something is probably wrong with your CUDA drivers and you should check your CUDA
+are not working as expected.
+In this case something is probably wrong with your CUDA drivers and you should check your CUDA
 installation.
 
 If you installed ``nvcc`` after installing the ``mhn`` package, you have to
 reinstall this package to gain access to the CUDA functions.
+
+If you cannot resolve ```CUDA_NOT_FUNCTIONAL``` by changing CUDA drivers, we recommend to install the package with CPU support only.
+This can be accomplished via:
+```bash
+export INSTALL_MHN_NO_CUDA=1
+pip install mhn
+```
 
 ## How to train a new MHN
 

--- a/setup.py
+++ b/setup.py
@@ -8,11 +8,12 @@ import platform
 from shutil import which
 import subprocess
 
-IS_WINDOWS = (platform.system() == 'Windows')   # get the operating system
-STATE_SIZE = 8                                  # the compiled code supports MHNs with maximum size of 32 * STATE_SIZE
-GENERATE_DEBUG_HTML = False                     # set this to True so that Cython generates a optimization HTML file
+IS_WINDOWS = (platform.system() == 'Windows')      # get the operating system
+STATE_SIZE = 8                                     # the compiled code supports MHNs with maximum size of 32 * STATE_SIZE
+GENERATE_DEBUG_HTML = False                        # set this to True so that Cython generates a optimization HTML file
+NO_CUDA_INSTALLATION_FLAG = "INSTALL_MHN_NO_CUDA"  # set this environmental variable to install CPU version only
 
-assert STATE_SIZE > 0                           # make sure STATE_SIZE is greater zero
+assert STATE_SIZE > 0                              # make sure STATE_SIZE is greater zero
 
 with open("README.md", 'r') as f:
     long_description = f.read()
@@ -57,6 +58,10 @@ def compile_cuda_code(folder, cuda_filename, lib_name, *extra_compile_args, addi
 
 # check if nvcc (the cuda compiler) is available on the device
 nvcc_available = int(which('nvcc') is not None)
+
+# check if manual instruction not to use CUDA was given
+if NO_CUDA_INSTALLATION_FLAG in os.environ:
+    nvcc_available = 0
 
 libraries = []
 extra_cuda_link_args = []


### PR DESCRIPTION
Hi,
I like the CUDA support, but sometimes it is quite tricky to install the right version of drivers (especially when working on clusters with different GPUs).

Hence, I'd like to be able to specify that CUDA should not be used at the installation stage. One way of doing this is via environmental variables, as `pip install mhn` command does not allow one to specify additional boolean flags.

Please, let me know what you think!